### PR TITLE
Revert "Fix missing symbol 'RSA_set0_key' with libressl

### DIFF
--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -466,7 +466,7 @@ static BIGNUM* bignum_from_base64(grpc_exec_ctx* exec_ctx, const char* b64) {
   return result;
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 // Provide compatibility across OpenSSL 1.02 and 1.1.
 static int RSA_set0_key(RSA* r, BIGNUM* n, BIGNUM* e, BIGNUM* d) {


### PR DESCRIPTION
It seems like this patch is not necessary anymore, and is actually now breaking the build (at least the Alpine build, using LibreSSL).

LibreSSL seems to now implement `RSA_set0_key`, which breaks the airmap CI (`tools/circleci/compile.sh`) with the following error:

> /usr/src/app/build/force_grpc/build/grpc/src/grpc/src/core/lib/security/credentials/jwt/jwt_verifier.cc: In function 'int RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)':
> /usr/src/app/build/force_grpc/build/grpc/src/grpc/src/core/lib/security/credentials/jwt/jwt_verifier.cc:472:12: error: 'int RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)' was declared 'extern' and later 'static' [-fpermissive]
>  static int RSA_set0_key(RSA* r, BIGNUM* n, BIGNUM* e, BIGNUM* d) {
>             ^~~~~~~~~~~~
> In file included from /usr/include/openssl/x509.h:96:0,
>                  from /usr/include/openssl/pem.h:71,
>                  from /usr/src/app/build/force_grpc/build/grpc/src/grpc/src/core/lib/security/credentials/jwt/jwt_verifier.cc:31:
> /usr/include/openssl/rsa.h:401:5: note: previous declaration of 'int RSA_set0_key(RSA*, BIGNUM*, BIGNUM*, BIGNUM*)'
>  int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
>      ^~~~~~~~~~~~
> make[5]: *** [CMakeFiles/grpc_cronet.dir/build.make:2624: CMakeFiles/grpc_cronet.dir/src/core/lib/security/credentials/jwt/jwt_verifier.cc.o] Error 1
> make[4]: *** [CMakeFiles/Makefile2:330: CMakeFiles/grpc_cronet.dir/all] Error 2
> make[3]: *** [Makefile:130: all] Error 2
> make[2]: *** [CMakeFiles/grpc.dir/build.make:112: grpc/src/grpc-stamp/grpc-build] Error 2
> make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/grpc.dir/all] Error 2
> make: *** [Makefile:84: all] Error 2
> CMake Error at external.cmake:138 (message):
>   Failed to find grpc cmake config file
> Call Stack (most recent call first):
>   CMakeLists.txt:42 (include)

Note: if this PR is accepted, then [this issue](https://github.com/grpc/grpc/pull/13522) can be closed as well.